### PR TITLE
Experimentally support json encoding/decoding

### DIFF
--- a/src/examples/slice_bugs.js
+++ b/src/examples/slice_bugs.js
@@ -150,5 +150,10 @@ const {
   let stdTx = new StdTx([sendMsg], /*fee,*/ [sig], 'test')
   let binary = codec.marshalBinary(stdTx)
   console.log(toHex(binary))
-  console.log(codec.marshalJson(stdTx))
+  let json = codec.marshalJson(stdTx)
+  console.log(json)
+
+  let stdTx2 = new StdTx()
+  codec.unMarshalJson(json, stdTx2)
+  console.log(stdTx2)
   

--- a/src/jsonDecoder.js
+++ b/src/jsonDecoder.js
@@ -1,0 +1,103 @@
+const Reflection = require("./reflect")
+let {
+    Types,
+    WireType,
+    WireMap
+} = require('./types')
+let { Buffer } = require('safe-buffer')
+
+const decodeJson = (value, instance) => {
+    Reflection.ownKeys(instance).forEach((key, idx) => {    
+        let type = instance.lookup(key) //only valid with BaseTypeAmino.todo: checking        
+        let data = decodeJsonField(value[key], idx, type, instance[key])
+        instance[key] = data
+    })
+}
+
+const decodeJsonField = (value, idx, type,instance) => {
+    switch (type) {
+        // fall-through
+        case Types.Int8:
+        case Types.Int16:
+        case Types.Int32:
+            return parseInt(value)
+        case Types.Int64:
+            return parseInt(value)
+        case Types.String:
+            return value    
+        case Types.Struct:
+            {          
+                return decodeJsonStruct(value, instance)
+            }
+        case Types.ByteSlice:
+            {
+                return decodeJsonSlice(value)
+            }
+        case Types.ArrayInterface:
+            {
+                return decodeJsonArray(value, instance, Types.ArrayInterface)
+            }
+        case Types.ArrayStruct:
+            {
+                return decodeJsonArray(value, instance, Types.ArrayStruct)
+            }
+        case Types.Interface:
+            {
+                return decodeJsonInterface(value, instance)
+            }
+        default:
+            {
+                throw new Error("There is no data type to decode:", type)
+            }
+    }
+}
+
+const decodeJsonStruct = (value, instance) => {
+    Reflection.ownKeys(instance).forEach((key, idx) => {    
+        let type = instance.lookup(key) //only valid with BaseTypeAmino.todo: checking          
+        let data = decodeJsonField(value, idx, type, instance[key])
+        instance[key] = data
+    })
+    return instance
+}
+
+const decodeJsonSlice = (value) => {
+    return Array.from(Buffer.from(value, 'base64'))
+}
+
+const decodeJsonInterface = (value, instance) => {
+    let typeName = Reflection.typeOf(instance);
+    if (!this.lookup(typeName)) {
+        throw new Error(`No ${typeName} was registered`)
+    }
+    let typeInfo = this.lookup(Reflection.typeOf(instance))
+    if (typeInfo && typeInfo.name) {
+        if (value.type !== typeInfo.name) {
+            throw new Error(`Type not match. expected: ${typeInfo.name}, but: ${value.type}`)
+        }
+    }
+
+    return decodeJson(value.value, instance.type) //dirty-hack
+}
+
+const decodeJsonArray = (value, instance, arrayType) => {
+    let result = []
+    let withPrefix = arrayType === Types.ArrayInterface ? true : false
+
+    for (let i = 0; i < value.length; i++) {
+        let type = Types.Struct
+        if (withPrefix) {
+            type = Types.Interface
+        }
+        let data = decodeJson(value[i], type)        
+        if (data) {       
+            result = result.concat(data)
+        }
+    }
+
+    return result;
+}
+
+module.exports = {
+    decodeJson
+}

--- a/src/jsonEncoder.js
+++ b/src/jsonEncoder.js
@@ -1,0 +1,136 @@
+const Reflection = require("./reflect")
+const Encoder = require("./encoder")
+let {
+    Types,
+    WireType,
+    WireMap
+} = require('./types')
+let { Buffer } = require('safe-buffer')
+
+const encodeJson = (instance, type) => {
+
+    let tmpInstance = instance;
+
+    //retrieve the single property of the Registered AminoType
+    if (type != Types.Struct && type != Types.Interface && type != Types.Array) { //only get the first property with type != Struct        
+        let keys = Reflection.ownKeys(instance);
+        if (keys.length > 0) { //type of AminoType class with single property
+            keys.forEach(key => {
+                let aminoType = instance.lookup(key)
+                if (type != aminoType) throw new TypeError("Amino type does not match")
+                tmpInstance = instance[key]
+                return;
+            })
+        }
+    }
+
+    switch (type) {
+        // fall-through
+        case Types.Int8:
+        case Types.Int16:
+        case Types.Int32:
+            {
+                return tmpInstance
+            }
+        case Types.Int64:
+            {
+                // https://github.com/tendermint/go-amino/blob/v0.14.1/json-encode.go#L99
+                // TODO: In go-amino, (u)int64 is encoded by string, because some languages like JS can't handle (u)int64
+                // So, It seemed that it is necessary to decode (u)int64 to library like bignumber.js?
+                return tmpInstance.toString()
+            }
+        case Types.String:
+            {
+                return tmpInstance
+            }
+
+        case Types.Struct:
+            {
+                return encodeJsonStruct(tmpInstance)
+            }
+        case Types.ByteSlice:
+            {
+                return encodeJsonSlice(tmpInstance)
+            }
+
+        case Types.ArrayStruct:
+            {
+                return encodeJsonArray(tmpInstance, Types.ArrayStruct)
+            }
+        case Types.ArrayInterface:
+            {
+                return encodeJsonArray(tmpInstance, Types.ArrayInterface)
+            }
+        case Types.Interface:
+            {
+                return encodeJsonInterface(tmpInstance)
+            }
+        default:
+            {
+                console.log("There is no data type to encode:", type)
+                break;
+            }
+    }
+}
+
+const encodeJsonInterface = (instance) => {
+    let value = encodeJson(instance, instance.type) //dirty-hack
+    let type = instance.info.name
+    return {type:type, value: value}
+
+}
+
+
+const encodeJsonStruct = (instance) => {
+    let result = {}
+    Reflection.ownKeys(instance).forEach((key) => {
+        let type = instance.lookup(key) //only valid with BaseTypeAmino.todo: checking 
+        let value = encodeJsonField(instance[key], type)
+        result[key] = value
+    })
+
+    return result;
+
+}
+
+
+
+const encodeJsonField = (typeInstance, type) => {    
+    let value = null
+    if (type == Types.Array) {        
+        value = encodeJsonArray(typeInstance)
+    } else {
+        value = encodeJson(typeInstance, type)
+    }
+
+    return value
+}
+
+const encodeJsonArray = (instance, arrayType) => {
+    let result = []
+    let withPrefix = arrayType === Types.ArrayInterface ? true : false
+
+    for (let i = 0; i < instance.length; ++i) {
+        let item = instance[i]      
+        
+        let type = item.type
+        if (withPrefix) {
+            type = Types.Interface
+        }
+        let data = encodeJson(item, type)        
+        if (data) {       
+            result = result.concat(data)
+        }
+    }
+
+    return result;
+}
+
+const encodeJsonSlice = (tmpInstance) => {
+    // In go-amino, bytes are encoded by base64 when json-encoding
+    return Buffer.from(tmpInstance).toString('base64')
+}
+
+module.exports = {
+    encodeJson
+}


### PR DESCRIPTION
Decoding is not much tested yet...
I will gradually improve decoding part.

And if you take this PR, I will make one issue.
https://github.com/tendermint/go-amino/blob/v0.14.1/json-encode.go#L99
In go-amino, (u)int64 is encoded by string, because some languages like JS can't handle (u)int64
So, It seemed that it is necessary to decode (u)int64 to library like bignumber.js?