### PR TITLE
Fix encoding int32, 64 to binFixed

### DIFF
--- a/src/binaryEncoder.js
+++ b/src/binaryEncoder.js
@@ -2,8 +2,6 @@ const Reflection = require("./reflect")
 const Encoder = require("./encoder")
 let {
     Types,
-    WireType,
-    WireMap
 } = require('./types')
 
 const encodeBinary = (instance, type, opts, isBare = true) => {
@@ -154,7 +152,7 @@ const encodeBinaryField = (typeInstance, idx, type, opts) => {
         encodeData = encodeTime(typeInstance, idx,false)
     } else {
         encodeData = encodeBinary(typeInstance, type, opts, false)
-        let encodeField = Encoder.encodeFieldNumberAndType(idx + 1, WireMap[type])
+        let encodeField = Encoder.encodeFieldNumberAndType(idx + 1, Reflection.typeToTyp3(type, opts))
         encodeData = encodeField.concat(encodeData)
     }
 
@@ -167,7 +165,7 @@ const encodeBinaryArray = (instance, arrayType, opts, isBare = true, idx = 0) =>
     for (let i = 0; i < instance.length; ++i) {
         let item = instance[i]
 
-        let encodeField = Encoder.encodeFieldNumberAndType(idx + 1, WireMap[Types.ArrayStruct])
+        let encodeField = Encoder.encodeFieldNumberAndType(idx + 1, Reflection.typeToTyp3(Types.ArrayStruct, opts))
         let itemType = arrayType == Types.ArrayInterface ? Types.Interface : Types.Struct
         let data = encodeBinary(item, itemType, opts, false)
         if (data) {
@@ -191,7 +189,7 @@ const encodeTime = (time, idx, isBare) => {
     if (!isBare) {
         result = Encoder.encodeUVarint(result.length).concat(result)
     }
-    let encodeField = Encoder.encodeFieldNumberAndType(idx + 1, WireMap[Types.Struct]) //notice: use Types.Struct -> Time is a special of Struct
+    let encodeField = Encoder.encodeFieldNumberAndType(idx + 1, Reflection.typeToTyp3(Types.Struct, opts)) //notice: use Types.Struct -> Time is a special of Struct
     result = encodeField.concat(result)
     return result
 

--- a/src/encoder.js
+++ b/src/encoder.js
@@ -33,7 +33,7 @@ const encodeInt16 = input => {
 const encodeInt32 = input => {
     let buffer = new ArrayBuffer(4); //4 byte
     let view = new DataView(buffer);
-    view.setUint32(0, input); // big endiant
+    view.setUint32(0, input, true); // little endiant
     return Array.from(new Uint8Array(buffer));
 }
 

--- a/src/jsonDecoder.js
+++ b/src/jsonDecoder.js
@@ -1,8 +1,6 @@
 const Reflection = require("./reflect")
 let {
     Types,
-    WireType,
-    WireMap
 } = require('./types')
 let { Buffer } = require('safe-buffer')
 

--- a/src/jsonEncoder.js
+++ b/src/jsonEncoder.js
@@ -1,9 +1,6 @@
 const Reflection = require("./reflect")
-const Encoder = require("./encoder")
 let {
     Types,
-    WireType,
-    WireMap
 } = require('./types')
 let { Buffer } = require('safe-buffer')
 

--- a/src/reflect.js
+++ b/src/reflect.js
@@ -1,4 +1,7 @@
-let { Types } = require('./types')
+let {
+    Types,
+    WireType,
+} = require('./types')
 let Factory = require('./typeFactory')
 
 const typeOf = instance => {
@@ -24,7 +27,44 @@ const ownKeys = instance => {
     })
 }
 
+const typeToTyp3 = (type, opts) => {
+    switch (type) {
+        case Types.Interface:
+            return WireType.ByteLength
+        case Types.ArrayInterface:
+        case Types.ArrayStruct:   
+            return WireType.ByteLength
+        case Types.String:
+            return WireType.ByteLength
+        case Types.Struct:
+        // case Types.Map:
+            return WireType.ByteLength
+        case Types.Int64:
+            if (opts.binFixed64) {
+                return WireType.Type8Byte
+            } else {
+                return WireType.Varint
+            }
+        case Types.Int32:
+            if (opts.binFixed32) {
+                return WireType.Type4Byte
+            } else {
+                return WireType.Varint
+            }
+        case Types.Int8:
+        case Types.Int16:
+            return WireType.Varint 
+        // case Types.Float64:
+        //      return WireType.Type8Byte
+        // case Types.Float32:
+        //      return WireType.Type4Byte
+        default:
+            throw new Error('"unsupported field type ' + type)       
+    }
+}
+
 module.exports = {
     typeOf,
-    ownKeys
+    ownKeys,
+    typeToTyp3,
 }

--- a/src/types.js
+++ b/src/types.js
@@ -32,8 +32,6 @@ const WireMap = {
     [Types.ArrayStruct]: WireType.ByteLength,
     [Types.ArrayInterface]: WireType.ByteLength,
     [Types.Interface]: WireType.ByteLength,
-   
-
 }
 
 WireType.keysOf = number => {

--- a/test/primitive.go
+++ b/test/primitive.go
@@ -7,6 +7,11 @@ import (
 	"github.com/tendermint/go-amino"
 )
 
+type FixedInt struct {
+	Int32 int32 `binary:"fixed32"`
+	Int64 int64 `binary:"fixed64"`
+}
+
 func PrintPrimitive() {
 	cdc := amino.NewCodec()
 
@@ -24,4 +29,13 @@ func PrintPrimitive() {
 
 	bz = cdc.MustMarshalBinaryLengthPrefixed("teststring유니코드")
 	fmt.Println("Encode string(teststring유니코드)", hex.EncodeToString(bz))
+
+	bz = cdc.MustMarshalBinaryLengthPrefixed(FixedInt{
+		Int32: 1234567,
+		Int64: 123456789,
+	})
+	fmt.Println(`FixedInt{
+	Int32(fixed32): 1234567,
+	Int64(fixed64):123456789,
+}`, hex.EncodeToString(bz))
 }

--- a/test/primitive.js
+++ b/test/primitive.js
@@ -2,6 +2,7 @@ const {
   Codec,
   TypeFactory,
   Types,
+  FieldOtions,
 } = require('../src/index')
 const { toHex } = require('./util')
 const assert = require('assert')
@@ -60,6 +61,27 @@ describe('Test encode primitive type int', () => {
   it('result of int64 should match', () => {
     let int64 = new Int64(123456789)
     assert.equal(toHex(codec.marshalBinary(int64)), '04959aef3a')
+  })
+
+  /*
+    FixedInt{
+      Int32(fixed32): 1234567,
+      Int64(fixed64):123456789,
+    } 0e0d87d612001115cd5b0700000000
+  */
+  it('result of fixed int32 and int64 should match', () => {
+    const FixedInt = TypeFactory.create('FixedInt', [
+      {
+        name: 'int32',
+        type: Types.Int32,
+      },
+      {
+        name: 'int64',
+        type: Types.Int64,
+      }
+    ])
+    let fixedInt = new FixedInt(1234567, 123456789)
+    assert.equal(toHex(codec.marshalBinary(fixedInt, new FieldOtions({binFixed64: true, binFixed32: true}))), '0e0d87d612001115cd5b0700000000')
   })
 })
 


### PR DESCRIPTION
#24 #21 
Add [typeToTyp3](https://github.com/tendermint/go-amino/blob/master/reflect.go#L195) to reflect.js
It passed simple test
But I guess decoding binFixed don't work yet